### PR TITLE
Fix keys with empty/null values from being dropped

### DIFF
--- a/src/xml.rs
+++ b/src/xml.rs
@@ -449,6 +449,13 @@ impl XmlBuilder {
       }
     } else if let Some(array) = node.as_array() {
       // Iterate over child array elements
+      if array.is_empty() {
+        if let Some(ref pk) = parent_key.as_ref() {
+          self.write_start_tag(pk, node)?;
+          self.write_end_tag(pk, node)?;
+        }
+        return Ok(());
+      }
       for child in array {
         if let Some(ref pk) = parent_key.as_ref() {
           self.write_start_tag(pk, child)?;

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -449,11 +449,10 @@ impl XmlBuilder {
       }
     } else if let Some(array) = node.as_array() {
       // Iterate over child array elements
-      if array.is_empty() {
-        if let Some(ref pk) = parent_key.as_ref() {
-          self.write_start_tag(pk, node)?;
-          self.write_end_tag(pk, node)?;
-        }
+      if array.is_empty() && parent_key.is_some() {
+        let pk = parent_key.as_ref().unwrap();
+        self.write_start_tag(pk, node)?;
+        self.write_end_tag(pk, node)?;
         return Ok(());
       }
       for child in array {

--- a/tests/integration/xml.rs
+++ b/tests/integration/xml.rs
@@ -248,6 +248,21 @@ fn build_childobj_pretty_false() {
 }
 
 #[test]
+fn build_empty_array_pretty_false() {
+  let object: JsonValue = serde_json::from_str(r#"{"ApplesList":[]}"#).unwrap();
+  let expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><ApplesList/>";
+
+  let mut xml_builder = XmlConfig::new()
+    .decl(Declaration::new(Version::XML10, Some(Encoding::UTF8), Some(true)))
+    .root_name("root")
+    .finalize();
+  let result = xml_builder.build_from_json(&object);
+
+  let actual = result.expect("Error building XML");
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn build_childobj_indent_tab() {
   let object = load_json("tests/data/childobj.json");
   let expected = indoc!(


### PR DESCRIPTION
Previously empty arrays were lost during JSON -> XML traversal. This caused semantic information (the presence of an empty list) to be lost in the XML output. The change preserves that information by emitting a self-closing tag for empty arrays.

JSON input

```json
{"ApplesList": []}
```

Before:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?><root/>
```

After: 
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?><ApplesList/>
```